### PR TITLE
Get expected target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @digitalbazaar/ezcap-express Changelog
 
+## 2.0.0 - TBD
+
+### Changed
+- **BREAKING**: Replace `expectedTarget` parameter with `getExpectedTarget`.
+  `getExpectedTarget` is an async function used to return the expected
+  target(s) for the invoked capability.
+
 ## 1.0.1 - 2021-03-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 2.0.0 - TBD
 
+### Added
+- Add optional `onError` handler which allows for errors to be wrappped
+  before being thrown.
+
 ### Changed
 - **BREAKING**: Replace `expectedTarget` parameter with `getExpectedTarget`.
   `getExpectedTarget` is an async function used to return the expected

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - **BREAKING**: Replace `expectedTarget` parameter with `getExpectedTarget`.
   `getExpectedTarget` is an async function used to return the expected
   target(s) for the invoked capability.
+- **BREAKING**: Remove the `logger` parameter. Errors may now be logged by the
+  `onError` handler.
 
 ## 1.0.1 - 2021-03-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,7 @@
 ## 2.0.0 - TBD
 
 ### Added
-- Add optional `onError` handler which allows for errors to be wrappped
-  before being thrown.
+- Add optional `onError` handler for customizable error handling.
 
 ### Changed
 - **BREAKING**: Replace `expectedTarget` parameter with `getExpectedTarget`.

--- a/lib/authorize.js
+++ b/lib/authorize.js
@@ -7,7 +7,6 @@ import {SECURITY_CONTEXT_V2_URL} from 'jsonld-signatures';
 import {parseSignatureHeader} from 'http-signature-header';
 import {suites} from 'jsonld-signatures';
 import {verifyCapabilityInvocation} from 'http-signature-zcap-verify';
-import noopLogger from './noopLogger.js';
 const {Ed25519Signature2018} = suites;
 
 const ZCAP_ROOT_PREFIX = 'urn:zcap:root:';
@@ -28,7 +27,6 @@ const ZCAP_ROOT_PREFIX = 'urn:zcap:root:';
  *   expected root capability identifiers for the expected targets.
  * @param {Function} options.getRootController - Used to get the root capability
  *   controller for the given root capability ID.
- * @param {object} [options.logger] - The logger instance to use.
  * @param {Function} [options.onError] - An error handler handler for
  *   customizable error handling.
  * @param {object} [options.suite] - The expected cryptography suite to use when
@@ -38,7 +36,7 @@ const ZCAP_ROOT_PREFIX = 'urn:zcap:root:';
  */
 export function authorizeZcapInvocation({
   documentLoader, expectedAction, expectedHost, getExpectedRootCapabilityId,
-  getExpectedTarget, getRootController, logger = noopLogger, onError,
+  getExpectedTarget, getRootController, onError,
   suite = new Ed25519Signature2018()
 } = {}) {
   assert.func(documentLoader, 'options.documentLoader');
@@ -152,10 +150,7 @@ export function authorizeZcapInvocation({
 
     // return HTTP 403 if verification fails
     if(!result.verified) {
-      const error = new Error('ZCAP authorization failed.');
-      error.details = {url};
-      error.cause = result.error;
-      logger.error(error);
+      _handleError({error: result.error, onError, throwError: false});
       return res.status(403).send();
     }
 
@@ -169,11 +164,13 @@ export function authorizeZcapInvocation({
   });
 }
 
-function _handleError({error, onError}) {
+function _handleError({error, onError, throwError = true}) {
   if(onError) {
     return onError({error});
   }
-  throw error;
+  if(throwError) {
+    throw error;
+  }
 }
 
 function _wrappedDocumentLoader({

--- a/lib/authorize.js
+++ b/lib/authorize.js
@@ -22,7 +22,7 @@ const ZCAP_ROOT_PREFIX = 'urn:zcap:root:';
  *   invoked capability.
  * @param {string} options.expectedHost - The expected host for the invoked
  *   capability.
- * @param {string|Array<string>} [options.expectedTarget] - The expected
+ * @param {Function} options.getExpectedTarget - Used to return the expected
  *   target(s) for the invoked capability.
  * @param {Function} [options.getExpectedRootCapabilityId] - Used to return the
  *   expected root capability identifiers for the expected targets.
@@ -35,20 +35,19 @@ const ZCAP_ROOT_PREFIX = 'urn:zcap:root:';
  * @returns {Function} Returns an Express.js middleware route handler.
  */
 export function authorizeZcapInvocation({
-  documentLoader, expectedAction, expectedHost, expectedTarget,
-  getExpectedRootCapabilityId, getRootController, logger = noopLogger,
+  documentLoader, expectedAction, expectedHost, getExpectedRootCapabilityId,
+  getExpectedTarget, getRootController, logger = noopLogger,
   suite = new Ed25519Signature2018()
 } = {}) {
   assert.func(documentLoader, 'options.documentLoader');
   assert.string(expectedHost, 'options.expectedHost');
+  assert.func(getExpectedTarget, 'options.getExpectedTarget');
+  assert.func(getRootController, 'options.getRootController');
 
   if(getExpectedRootCapabilityId &&
     typeof getExpectedRootCapabilityId !== 'function') {
     throw new Error(
       '"options.getExpectedRootCapabilityId" must be a function.');
-  }
-  if(!(getRootController && typeof getRootController === 'function')) {
-    throw new Error('"options.getRootController" is required.');
   }
 
   return asyncHandler(async (req, res, next) => {
@@ -60,8 +59,7 @@ export function authorizeZcapInvocation({
       throw new Error('Missing or invalid "authorization" header.');
     }
     const {keyId} = params;
-    const _expectedTarget =
-      expectedTarget || req.protocol + '://' + req.get('host') + req.url;
+    const _expectedTarget = await getExpectedTarget({req});
 
     let _expectedAction = expectedAction;
 

--- a/lib/authorize.js
+++ b/lib/authorize.js
@@ -29,8 +29,8 @@ const ZCAP_ROOT_PREFIX = 'urn:zcap:root:';
  * @param {Function} options.getRootController - Used to get the root capability
  *   controller for the given root capability ID.
  * @param {object} [options.logger] - The logger instance to use.
- * @param {Function} [options.onError] - An error handler to call. Allows for
- *   errors to be wrappped before being thrown.
+ * @param {Function} [options.onError] - An error handler handler for
+ *   customizable error handling.
  * @param {object} [options.suite] - The expected cryptography suite to use when
  *   verifying digital signatures.
  *

--- a/lib/authorize.js
+++ b/lib/authorize.js
@@ -43,13 +43,9 @@ export function authorizeZcapInvocation({
   assert.string(expectedHost, 'options.expectedHost');
   assert.func(getExpectedTarget, 'options.getExpectedTarget');
   assert.func(getRootController, 'options.getRootController');
-  assert.optionalFunc(onError);
-
-  if(getExpectedRootCapabilityId &&
-    typeof getExpectedRootCapabilityId !== 'function') {
-    throw new Error(
-      '"options.getExpectedRootCapabilityId" must be a function.');
-  }
+  assert.optionalFunc(
+    getExpectedRootCapabilityId, 'options.getExpectedRootCapabilityId');
+  assert.optionalFunc(onError, 'options.onError');
 
   return asyncHandler(async (req, res, next) => {
     // originalUrl must be used to support nested express routers

--- a/lib/authorize.js
+++ b/lib/authorize.js
@@ -62,7 +62,18 @@ export function authorizeZcapInvocation({
       throw new Error('Missing or invalid "authorization" header.');
     }
     const {keyId} = params;
-    const _expectedTarget = await getExpectedTarget({req});
+
+    let expectedTarget;
+    try {
+      // getExpectedTarget may throw an error
+      ({expectedTarget} = await getExpectedTarget({req}));
+      if(!(typeof expectedTarget === 'string' ||
+        Array.isArray(expectedTarget))) {
+        throw new Error('Invalid "getExpectedTarget" handler.');
+      }
+    } catch(error) {
+      return _handleError({error, onError});
+    }
 
     let _expectedAction = expectedAction;
 
@@ -81,15 +92,15 @@ export function authorizeZcapInvocation({
       // retrieve the root capability given the request and expected params
       // return value can be a string or an array of strings
       expectedRootCapability = await getExpectedRootCapabilityId({
-        req, expectedHost, expectedTarget: _expectedTarget,
+        req, expectedHost, expectedTarget,
         expectedAction: _expectedAction
       });
-    } else if(Array.isArray(_expectedTarget)) {
-      expectedRootCapability = _expectedTarget.map(
+    } else if(Array.isArray(expectedTarget)) {
+      expectedRootCapability = expectedTarget.map(
         t => `urn:zcap:root:${encodeURIComponent(t)}`);
     } else {
       expectedRootCapability =
-        `urn:zcap:root:${encodeURIComponent(_expectedTarget)}`;
+        `urn:zcap:root:${encodeURIComponent(expectedTarget)}`;
     }
 
     // retrieves the root capability that was invoked
@@ -102,7 +113,7 @@ export function authorizeZcapInvocation({
       }
       if(!rootCapabilityId) {
         const error = new Error(
-          `Capability target "${id}" is not an expected root ` +
+          `The given capability "${id}" is not an expected root ` +
           `capability "${expectedRootCapability}".`);
         error.details = {
           actual: id,
@@ -112,7 +123,7 @@ export function authorizeZcapInvocation({
         return _handleError({error, onError});
       }
       return _getRootCapability({
-        getRootController, req, expectedHost, expectedTarget: _expectedTarget,
+        getRootController, req, expectedHost, expectedTarget,
         expectedAction: _expectedAction, rootCapabilityId
       });
     }
@@ -128,12 +139,12 @@ export function authorizeZcapInvocation({
         documentLoader,
         expectedAction: _expectedAction,
         expectedHost,
-        expectedTarget: _expectedTarget,
+        expectedTarget,
         getRootController,
         req,
       }),
       getInvokedCapability,
-      expectedTarget: _expectedTarget,
+      expectedTarget,
       expectedAction: _expectedAction,
       expectedRootCapability,
       keyId

--- a/lib/authorize.js
+++ b/lib/authorize.js
@@ -29,6 +29,8 @@ const ZCAP_ROOT_PREFIX = 'urn:zcap:root:';
  * @param {Function} options.getRootController - Used to get the root capability
  *   controller for the given root capability ID.
  * @param {object} [options.logger] - The logger instance to use.
+ * @param {Function} [options.onError] - An error handler to call. Allows for
+ *   errors to be wrappped before being thrown.
  * @param {object} [options.suite] - The expected cryptography suite to use when
  *   verifying digital signatures.
  *
@@ -36,13 +38,14 @@ const ZCAP_ROOT_PREFIX = 'urn:zcap:root:';
  */
 export function authorizeZcapInvocation({
   documentLoader, expectedAction, expectedHost, getExpectedRootCapabilityId,
-  getExpectedTarget, getRootController, logger = noopLogger,
+  getExpectedTarget, getRootController, logger = noopLogger, onError,
   suite = new Ed25519Signature2018()
 } = {}) {
   assert.func(documentLoader, 'options.documentLoader');
   assert.string(expectedHost, 'options.expectedHost');
   assert.func(getExpectedTarget, 'options.getExpectedTarget');
   assert.func(getRootController, 'options.getRootController');
+  assert.optionalFunc(onError);
 
   if(getExpectedRootCapabilityId &&
     typeof getExpectedRootCapabilityId !== 'function') {
@@ -98,9 +101,15 @@ export function authorizeZcapInvocation({
         rootCapabilityId = expectedRootCapability;
       }
       if(!rootCapabilityId) {
-        throw new Error(
+        const error = new Error(
           `Capability target "${id}" is not an expected root ` +
           `capability "${expectedRootCapability}".`);
+        error.details = {
+          actual: id,
+          expected: expectedRootCapability,
+        };
+
+        return _handleError({error, onError});
       }
       return _getRootCapability({
         getRootController, req, expectedHost, expectedTarget: _expectedTarget,
@@ -147,6 +156,13 @@ export function authorizeZcapInvocation({
     // an error
     process.nextTick(next);
   });
+}
+
+function _handleError({error, onError}) {
+  if(onError) {
+    return onError({error});
+  }
+  throw error;
 }
 
 function _wrappedDocumentLoader({

--- a/lib/authorize.js
+++ b/lib/authorize.js
@@ -1,6 +1,7 @@
 /*!
  * Copyright (c) 2021 Digital Bazaar, Inc. All rights reserved.
  */
+import assert from 'assert-plus';
 import asyncHandler from 'express-async-handler';
 import {SECURITY_CONTEXT_V2_URL} from 'jsonld-signatures';
 import {parseSignatureHeader} from 'http-signature-header';
@@ -38,8 +39,9 @@ export function authorizeZcapInvocation({
   getExpectedRootCapabilityId, getRootController, logger = noopLogger,
   suite = new Ed25519Signature2018()
 } = {}) {
-  _assertOk(documentLoader, 'options.documentLoader');
-  _assertString(expectedHost, 'options.expectedHost');
+  assert.func(documentLoader, 'options.documentLoader');
+  assert.string(expectedHost, 'options.expectedHost');
+
   if(getExpectedRootCapabilityId &&
     typeof getExpectedRootCapabilityId !== 'function') {
     throw new Error(
@@ -147,18 +149,6 @@ export function authorizeZcapInvocation({
     // an error
     process.nextTick(next);
   });
-}
-
-function _assertString(arg, msg) {
-  if(typeof (arg) !== 'string') {
-    throw new TypeError(`"${msg}" must be a string.`);
-  }
-}
-
-function _assertOk(arg, msg) {
-  if(!arg) {
-    throw new TypeError(`"${msg}" is required.`);
-  }
 }
 
 function _wrappedDocumentLoader({

--- a/lib/authorize.js
+++ b/lib/authorize.js
@@ -52,7 +52,8 @@ export function authorizeZcapInvocation({
   }
 
   return asyncHandler(async (req, res, next) => {
-    const {url, method, headers} = req;
+    // originalUrl must be used to support nested express routers
+    const {originalUrl: url, method, headers} = req;
     let params;
     try {
       ({params} = parseSignatureHeader(headers.authorization));

--- a/lib/authorize.js
+++ b/lib/authorize.js
@@ -64,7 +64,8 @@ export function authorizeZcapInvocation({
       ({expectedTarget} = await getExpectedTarget({req}));
       if(!(typeof expectedTarget === 'string' ||
         Array.isArray(expectedTarget))) {
-        throw new Error('Invalid "getExpectedTarget" handler.');
+        throw new Error('Return value from "getExpectedTarget" must be a ' +
+          'string or an array.');
       }
     } catch(error) {
       return _handleError({error, onError});

--- a/lib/noopLogger.js
+++ b/lib/noopLogger.js
@@ -1,8 +1,0 @@
-/*!
- * Copyright (c) 2021 Digital Bazaar, Inc. All rights reserved.
- */
-export default new Proxy({}, {
-  get() {
-    return () => {};
-  }
-});

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test-node": "cross-env NODE_ENV=test mocha -r esm --preserve-symlinks -t 30000 -A -R ${REPORTER:-spec} --require tests/test-mocha.js tests/*.spec.js"
   },
   "dependencies": {
+    "assert-plus": "^1.0.0",
     "esm": "^3.2.25",
     "express-async-handler": "^1.1.4",
     "http-signature-header": "^2.0.1",


### PR DESCRIPTION
see changelog

@dlongley I opted for arranging things so that `getExpectedTarget` can throw a very specific error as needed.