### PR TITLE
Add missing `allowTargetAttenuation` option w/default `true`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @digitalbazaar/ezcap-express Changelog
 
+## 3.3.1 - 2021-xx-xx
+
+### Added
+- **BREAKING**: Add missing `allowTargetAttenuation` option that defaults
+  to `true` to support RESTful-based attenuated delegation as the documentation
+  describes.
+
 ## 3.3.0 - 2021-05-19
 
 ### Added

--- a/lib/authorize.js
+++ b/lib/authorize.js
@@ -17,6 +17,15 @@ const ZCAP_ROOT_PREFIX = 'urn:zcap:root:';
  * @param {object} options - Options hashmap.
  * @param {object} options.documentLoader - Document loader used to load
  *   DID Documents, capability documents, and JSON-LD Contexts.
+ * @param {string} options.expectedHost - The expected host for the invoked
+ *   capability.
+ * @param {Function} options.getExpectedTarget - Used to return the expected
+ *   target(s) for the invoked capability.
+ * @param {Function} options.getRootController - Used to get the root capability
+ *   controller for the given root capability ID.
+ * @param {boolean} [options.allowTargetAttenuation=true] - Allow the
+ *   invocationTarget of a delegation chain to be increasingly restrictive
+ *   based on a hierarchical RESTful URL structure.
  * @param {string} [options.expectedAction] - The expected action for the
  *   invoked capability; use this or `getExpectedAction`, not both.
  * @param {Function} [options.getExpectedAction] - Used to return the
@@ -27,14 +36,8 @@ const ZCAP_ROOT_PREFIX = 'urn:zcap:root:';
  *   method in the request (i.e., typical method-based express/connect routing);
  *   if the handler code path is determined by some other means, e.g., the
  *   request body, then `getExpectedAction` MUST be used.
- * @param {string} options.expectedHost - The expected host for the invoked
- *   capability.
- * @param {Function} options.getExpectedTarget - Used to return the expected
- *   target(s) for the invoked capability.
  * @param {Function} [options.getExpectedRootCapabilityId] - Used to return the
  *   expected root capability identifiers for the expected targets.
- * @param {Function} options.getRootController - Used to get the root capability
- *   controller for the given root capability ID.
  * @param {Function} [options.inspectCapabilityChain] - A function that can
  *   inspect a capability chain, e.g., to check for revocations.
  * @param {Function} [options.onError] - An error handler handler for
@@ -45,9 +48,9 @@ const ZCAP_ROOT_PREFIX = 'urn:zcap:root:';
  * @returns {Function} Returns an Express.js middleware route handler.
  */
 export function authorizeZcapInvocation({
-  documentLoader, expectedAction, getExpectedAction,
-  expectedHost, getExpectedRootCapabilityId,
-  getExpectedTarget, getRootController, inspectCapabilityChain,
+  documentLoader, expectedHost, getExpectedTarget, getRootController,
+  allowTargetAttenuation = true, expectedAction, getExpectedAction,
+  getExpectedRootCapabilityId, inspectCapabilityChain,
   onError, suite = new Ed25519Signature2020()
 } = {}) {
   assert.func(documentLoader, 'options.documentLoader');
@@ -198,7 +201,8 @@ export function authorizeZcapInvocation({
       expectedAction: _expectedAction,
       expectedRootCapability,
       inspectCapabilityChain,
-      keyId
+      keyId,
+      allowTargetAttenuation
     });
 
     // return HTTP 403 if verification fails


### PR DESCRIPTION
This was missing previously -- and presume it wasn't on purpose since this is one of the main points of the lib.