### PR TITLE
Test with node 20.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [14.x, 16.x, 18.x, 20.8.0, 20.8.1]
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
Github action here demonstrates issue with the `authorization` header in Node.js v20.8.1.

https://github.com/digitalbazaar/ezcap-express/actions/runs/6551164704/job/17791818455