### PR TITLE
Add additional unit test for zcap invocation with query params.

### DIFF
--- a/tests/10-api.spec.js
+++ b/tests/10-api.spec.js
@@ -209,7 +209,7 @@ describe('ezcap-express', () => {
       res.data.message.should.equal('Post request was successful.');
     });
     it('should succeed when query params are used', async () => {
-      const url = `${BASE_URL}/documents?foo=bar&s=03-20-2024%2000:00%20UTC`;
+      const url = `${BASE_URL}/documents${QUERY}`;
       const invocationSigner = await getInvocationSigner({seed: ADMIN_SEED});
 
       const zcapClient = new ZcapClient({

--- a/tests/10-api.spec.js
+++ b/tests/10-api.spec.js
@@ -37,6 +37,7 @@ const documentLoader = loader.build();
 let BASE_HOST;
 // https://host:port
 let BASE_URL;
+const QUERY = '?foo=bar&s=03-20-2024%2000:00%20UTC';
 
 const key = fs.readFileSync(__dirname + '/key.pem');
 const cert = fs.readFileSync(__dirname + '/cert.pem');
@@ -96,7 +97,7 @@ async function _setupApp() {
       getExpectedValues() {
         return {
           host: BASE_HOST,
-          rootInvocationTarget: [`${BASE_URL}/documents`]
+          rootInvocationTarget: [`${BASE_URL}/documents`, `${BASE_URL}/documents${QUERY}`]
         };
       },
       getRootController() {
@@ -201,6 +202,28 @@ describe('ezcap-express', () => {
         res = await zcapClient.write({url, json: {name: 'test'}});
       } catch(e) {
         err = e;
+      }
+      should.exist(res);
+      should.not.exist(err);
+      res.status.should.equal(200);
+      res.data.message.should.equal('Post request was successful.');
+    });
+    it('should succeed when query params are used', async () => {
+      const url = `${BASE_URL}/documents?foo=bar&s=03-20-2024%2000:00%20UTC`;
+      const invocationSigner = await getInvocationSigner({seed: ADMIN_SEED});
+
+      const zcapClient = new ZcapClient({
+        agent,
+        SuiteClass: Ed25519Signature2020,
+        invocationSigner
+      });
+      let res;
+      let err;
+      try {
+        res = await zcapClient.write({url, json: {name: 'test'}});
+      } catch(e) {
+        err = e;
+        console.log(e)
       }
       should.exist(res);
       should.not.exist(err);


### PR DESCRIPTION
When a zcap invocation is made with query params that contain a `:` character, the invocation fails to verify. This is due to an issue in `http-signature-zcap-verify` where the `invocationTarget` used to validate the proof can be calculated incorrectly. This happens because the express `req.originalUrl` value is used to construct the `invocationTarget`, and when a query contains a `:` the host is never added back into the `invocationTarget`. This pr adds unit tests to account for this case. 

The fix for this case can be found in https://github.com/digitalbazaar/http-signature-zcap-verify/pull/35